### PR TITLE
New/reply

### DIFF
--- a/keybase-chat.el
+++ b/keybase-chat.el
@@ -313,8 +313,7 @@ Each entry is of the form (CHANNEL-INFO UNREAD")
 
 (defun keybase-reply-to-message ()
   (interactive)
-  (let ((reply-to-msgid (keybase--find-message-at-point (point)))
-        (sender (get-char-property (point) 'keybase-sender)))
+  (let ((reply-to-msgid (keybase--find-message-at-point (point))))
     (if reply-to-msgid
         (keybase--input (read-from-minibuffer "Reply: " ) reply-to-msgid)
       (message "No message at point"))))
@@ -577,9 +576,7 @@ Each entry is of the form (CHANNEL-INFO UNREAD")
                (insert (propertize (third element) 'face 'keybase-message-text-content-code))
                (insert "\n"))
               (:user
-               (insert (keybase--make-clickable-username (cdr element) :include-prefix t :highlight t)))
-              (:reply
-               (insert ("| ") )))))))
+               (insert (keybase--make-clickable-username (cdr element) :include-prefix t :highlight t))))))))
 
 (defun keybase--insert-markup-inner (content)
   (loop for v in content
@@ -943,11 +940,11 @@ once it is received from the server."
             for nl = (search-forward-regexp "\n" nil t)
             while nl
             do (let ((content (buffer-substring pos nl)))
-     (condition-case err
-         (progn
-           (keybase--handle-incoming-chat-message (json-read-from-string content))
-           (setq pos nl))
-       (json-readtable-error
+                 (condition-case err
+                     (progn
+                       (keybase--handle-incoming-chat-message (json-read-from-string content))
+                       (setq pos nl))
+                   (json-readtable-error
                     (message "ate bad json: %S" content)
                     (setq pos nl)))))
       (delete-region (point-min) (point)))))

--- a/keybase-chat.el
+++ b/keybase-chat.el
@@ -609,9 +609,9 @@ ID may be nil, in which case this message represents an
 in-progress message which is inserted while a new message is
 being inserted. It will later be replaced with the real content
 once it is received from the server."
-  (let ((inhibit-read-only t))
-    (let ((start (point)))
-      (insert (propertize (funcall keybase-attribution sender timestamp)
+  (let ((inhibit-read-only t)
+        (start (point)))
+    (insert (propertize (funcall keybase-attribution sender timestamp)
                           'face 'keybase-message-from))
       (let ((text-start (point)))
         (when (> (length message) 0)
@@ -633,7 +633,7 @@ once it is received from the server."
                                            (list 'keybase-in-progress gen-id
                                                  'keybase-content message
                                                  'face 'keybase-message-text-content-in-progress)
-                                         (list 'keybase-remote-message-id id)))))))))
+                                         (list 'keybase-remote-message-id id))))))))
 
 (defun keybase--insert-message (id timestamp sender message image)
   (save-excursion


### PR DESCRIPTION
Added functionality to reply to messages and to show these replies in channel mode:

[username1] 13:01
| [username0] 13:00
| original message
reply to original message

for consistency reasons this means that messages are now displayed on a new line following the attribution (instead of right after the attribution)

Looking forward to any feedback. Once this code has been approved, I'll proceed with my implementations of editing messages and sending attachments.
