### PR TITLE
Edit messages and make datetime format customizable

### DIFF
--- a/keybase-chat.el
+++ b/keybase-chat.el
@@ -11,6 +11,8 @@
   :prefix 'keybase
   :group 'applications)
 
+
+
 (defcustom keybase--program "keybase"
   "The name of the keybase binary"
   :type 'string
@@ -21,6 +23,11 @@
 It will be given two arguments, the timestamp of the message in seconds since
 the epoch and the sender's keybase name."
   :type 'function
+  :group 'keybase)
+
+(defcustom keybase--dateformat "%H:%M"
+  "The name of the keybase binary"
+  :type 'string
   :group 'keybase)
 
 (defcustom keybase-channel-mode-hook nil
@@ -534,13 +541,10 @@ Each entry is of the form (CHANNEL-INFO UNREAD")
           when (equal type "text")
           do (keybase--insert-message id timestamp sender (keybase--json-find content '(text body)) nil reply-to-msgid))))
 
-(defun keybase--format-date (timestamp)
-  (let ((time (seconds-to-time (/ timestamp 1000))))
-    (format-time-string "%Y-%m-%d %H:%M:%S" time)))
 
-(defun keybase--format-simple-date (timestamp)
+(defun keybase--format-custom-date (timestamp)
   (let ((time (seconds-to-time (/ timestamp 1000))))
-    (format-time-string "%H:%M" time)))
+    (format-time-string keybase--dateformat time)))
 
 (defun keybase--recompute-modeline ()
   (setq keybase-display-notifications-string (keybase--make-unread-notification-string))
@@ -567,7 +571,7 @@ Each entry is of the form (CHANNEL-INFO UNREAD")
 (defun keybase-default-attribution (sender timestamp)
   (format "[%s] %s "
           (keybase--make-clickable-username sender :highlight nil)
-          (keybase--format-simple-date timestamp)))
+          (keybase--format-custom-date timestamp)))
 
 (defvar keybase--first-paragraph nil)
 

--- a/keybase-chat.el
+++ b/keybase-chat.el
@@ -313,8 +313,7 @@ Each entry is of the form (CHANNEL-INFO UNREAD")
 
 (defun keybase-reply-to-message ()
   (interactive)
-  (let ((reply-to-msgid (keybase--find-message-at-point (point)))
-        (sender (get-char-property (point) 'keybase-sender)))
+  (let ((reply-to-msgid (keybase--find-message-at-point (point))))
     (if reply-to-msgid
         (keybase--input (read-from-minibuffer "Reply: " ) reply-to-msgid)
       (message "No message at point"))))
@@ -577,9 +576,7 @@ Each entry is of the form (CHANNEL-INFO UNREAD")
                (insert (propertize (third element) 'face 'keybase-message-text-content-code))
                (insert "\n"))
               (:user
-               (insert (keybase--make-clickable-username (cdr element) :include-prefix t :highlight t)))
-              (:reply
-               (insert ("| ") )))))))
+               (insert (keybase--make-clickable-username (cdr element) :include-prefix t :highlight t))))))))
 
 (defun keybase--insert-markup-inner (content)
   (loop for v in content
@@ -943,11 +940,11 @@ once it is received from the server."
             for nl = (search-forward-regexp "\n" nil t)
             while nl
             do (let ((content (buffer-substring pos nl)))
-     (condition-case err
-         (progn
-           (keybase--handle-incoming-chat-message (json-read-from-string content))
-           (setq pos nl))
-       (json-readtable-error
+                 (condition-case err
+                     (progn
+                       (keybase--handle-incoming-chat-message (json-read-from-string content))
+                       (setq pos nl))
+                   (json-readtable-error
                     (message "ate bad json: %S" content)
                     (setq pos nl)))))
       (delete-region (point-min) (point)))))

--- a/keybase-chat.el
+++ b/keybase-chat.el
@@ -25,8 +25,8 @@ the epoch and the sender's keybase name."
   :type 'function
   :group 'keybase)
 
-(defcustom keybase--dateformat "%H:%M"
-  "The name of the keybase binary"
+(defcustom keybase--datetime-format "%H:%M:%S"
+  "The datetime format used to convert timestamps"
   :type 'string
   :group 'keybase)
 
@@ -544,7 +544,7 @@ Each entry is of the form (CHANNEL-INFO UNREAD")
 
 (defun keybase--format-custom-date (timestamp)
   (let ((time (seconds-to-time (/ timestamp 1000))))
-    (format-time-string keybase--dateformat time)))
+    (format-time-string keybase--datetime-format time)))
 
 (defun keybase--recompute-modeline ()
   (setq keybase-display-notifications-string (keybase--make-unread-notification-string))

--- a/keybase-chat.el
+++ b/keybase-chat.el
@@ -609,9 +609,9 @@ ID may be nil, in which case this message represents an
 in-progress message which is inserted while a new message is
 being inserted. It will later be replaced with the real content
 once it is received from the server."
-  (let ((inhibit-read-only t))
-    (let ((start (point)))
-      (insert (propertize (funcall keybase-attribution sender timestamp)
+  (let ((inhibit-read-only t)
+        (start (point)))
+    (insert (propertize (funcall keybase-attribution sender timestamp)
                           'face 'keybase-message-from))
       (let ((text-start (point)))
         (when (> (length message) 0)
@@ -633,7 +633,7 @@ once it is received from the server."
                                            (list 'keybase-in-progress gen-id
                                                  'keybase-content message
                                                  'face 'keybase-message-text-content-in-progress)
-                                         (list 'keybase-remote-message-id id)))))))))
+                                         (list 'keybase-remote-message-id id))))))))
 
 (defun keybase--insert-message (id timestamp sender message image)
   (save-excursion


### PR DESCRIPTION
In addition to being able to reply to messages (`C-c C-r`), it's now also possible to edit messages (`C-c C-e`). Furthermore, the datetime format used in the message attribution is now customizable (in `keybase--datetime-format`)

This branch includes the `New/reply` one, so if you would rather work from this one, feel free to close the `New/reply` pull request.